### PR TITLE
docs: hide real name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ wechaty.use(QRCodeTerminal(options))
 
 ## Maintainers
 
-- @gcaufy - [Cheng GONG](https://github.com/Gcaufy) (龚澄), Creator of [WePY](https://github.com/tencent/wepy)
+- @gcaufy - [Gcuafy](https://github.com/Gcaufy), Creator of [WePY](https://github.com/tencent/wepy)
 - @huan - [Huan LI](https://github.com/huan) ([李卓桓](http://linkedin.com/in/zixia)), Tencent TVP of Chatbot
 
 ## Copyright & License


### PR DESCRIPTION
I'd rather than use the github id instead of real name. separate from working.  :0)

For the commit and pull request history, it doesn't really matter, we can just leave them.